### PR TITLE
Feature/upgrade dbt artifacts

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -27,6 +27,8 @@ models:
       +schema: build
     core_warehouse:
       +schema: wh
+  dbt_artifacts:
+    +schema: dbt_run__audit
 
 vars:
   # labels for generated race/ethnicity groups

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -19,6 +19,7 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+on-run-end: "{% if target.name == 'prod' %}{{ dbt_artifacts.upload_results(results) }}{% endif %}"
 
 models:
   edu_wh:
@@ -29,6 +30,7 @@ models:
       +schema: wh
   dbt_artifacts:
     +schema: dbt_run__audit
+    +tags: ['bypass_rls']
 
 vars:
   # labels for generated race/ethnicity groups

--- a/dbt/packages.yml
+++ b/dbt/packages.yml
@@ -2,4 +2,4 @@ packages:
   - git: "https://github.com/edanalytics/edu_wh.git"
     revision: 0.1.0
   - package: brooklyn-data/dbt_artifacts
-    version: 0.8.0
+    version: [">=2.2.2", "<3.0.0"]


### PR DESCRIPTION
This upgrades the dbt_artifacts package to the latest version. The new dbt_artifacts schema is `{target}_dbt_run__audit`, and RLS is automatically bypassed. Artifacts are only uploaded on a prod run, though this can be customized by the Stadium implementer.