### PR TITLE
Fix/param store region name

### DIFF
--- a/airflow/configs/airflow_config_dev.yml
+++ b/airflow/configs/airflow_config_dev.yml
@@ -25,7 +25,7 @@ aws_param_store_dag:
   default_args: *default_task_args
 
   ssm_prefix: '/stadium/PARTNER/connections/'
-  region_name: 'us-west-2'
+  region_name: 'us-east-2'
 
 
 

--- a/airflow/configs/airflow_config_dev.yml
+++ b/airflow/configs/airflow_config_dev.yml
@@ -24,8 +24,8 @@ aws_param_store_dag:
   schedule_interval: null
   default_args: *default_task_args
 
-  ssm_prefix: '/airflow/variables/dev/'
-  s3_region: 'us-west-2'
+  ssm_prefix: '/stadium/PARTNER/connections/'
+  region_name: 'us-west-2'
 
 
 

--- a/airflow/configs/airflow_config_dev.yml
+++ b/airflow/configs/airflow_config_dev.yml
@@ -19,7 +19,7 @@ default_task_args: &default_task_args
 
 
 
-### AWS Parameter Store to S3 DAG
+### AWS Parameter Store to Airflow connections DAG
 aws_param_store_dag:
   schedule_interval: null
   default_args: *default_task_args

--- a/airflow/configs/airflow_config_prod.yml
+++ b/airflow/configs/airflow_config_prod.yml
@@ -25,7 +25,7 @@ aws_param_store_dag:
   default_args: *default_task_args
 
   ssm_prefix: '/stadium/PARTNER/connections/'
-  region_name: 'us-west-2'
+  region_name: 'us-east-2'
 
 
 

--- a/airflow/configs/airflow_config_prod.yml
+++ b/airflow/configs/airflow_config_prod.yml
@@ -24,8 +24,8 @@ aws_param_store_dag:
   schedule_interval: null
   default_args: *default_task_args
 
-  ssm_prefix: '/airflow/variables/prod/'
-  s3_region: 'us-west-2'
+  ssm_prefix: '/stadium/PARTNER/connections/'
+  region_name: 'us-west-2'
 
 
 

--- a/airflow/configs/airflow_config_prod.yml
+++ b/airflow/configs/airflow_config_prod.yml
@@ -19,7 +19,7 @@ default_task_args: &default_task_args
 
 
 
-### AWS Parameter Store to S3 DAG
+### AWS Parameter Store to Airflow connections DAG
 aws_param_store_dag:
   schedule_interval: null
   default_args: *default_task_args


### PR DESCRIPTION
This fixes the ParamStore DAG parameters to match ParamStore DAG refactor in EA Airflow Util [PR11](https://github.com/edanalytics/ea_airflow_util/pull/11).