### PR TITLE
Update pip install statements to airflow venv to clone private repos …

### DIFF
--- a/init/venv-airflow-init.sh
+++ b/init/venv-airflow-init.sh
@@ -14,7 +14,22 @@ CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${A
 pip install "apache-airflow[amazon, snowflake, slack, postgres]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"  --quiet
 pip install airflow-dbt
 
-# Install EDU packages
-pip install -e git+https://github.com/edanalytics/ea_airflow_util.git@v0.1.0#egg=ea_airflow_util
-pip install -e git+https://github.com/edanalytics/edfi_api_client.git@v0.1.0#egg=edfi_api_client
-pip install -e git+https://github.com/edanalytics/edu_edfi_airflow.git@v0.1.0#egg=edu_edfi_airflow
+### Install EDU packages
+pip install edfi_api_client
+
+# Install executable repos to the `code` directory.
+cd ~/code
+
+git clone https://github.com/edanalytics/ea_airflow_util.git
+git clone https://github.com/edanalytics/edu_edfi_airflow.git
+
+pip install -e ./ea_airflow_util
+pip install -e ./edu_edfi_airflow
+
+# Checkout the most recent tagged releases.
+# UPDATE THESE LINES AS VERSIONS INCREMENT.
+git -C ./ea_airflow_util  checkout tags/v0.1.0
+git -C ./edu_edfi_airflow checkout tags/v0.1.0
+
+# Return to the original path.
+cd -

--- a/init/venv-airflow-init.sh
+++ b/init/venv-airflow-init.sh
@@ -23,13 +23,13 @@ cd ~/code
 git clone https://github.com/edanalytics/ea_airflow_util.git
 git clone https://github.com/edanalytics/edu_edfi_airflow.git
 
-pip install -e ./ea_airflow_util
-pip install -e ./edu_edfi_airflow
+pip install -e ea_airflow_util
+pip install -e edu_edfi_airflow
 
 # Checkout the most recent tagged releases.
 # UPDATE THESE LINES AS VERSIONS INCREMENT.
-git -C ./ea_airflow_util  checkout tags/v0.1.0
-git -C ./edu_edfi_airflow checkout tags/v0.1.0
+git -C ea_airflow_util  checkout tags/v0.1.0
+git -C edu_edfi_airflow checkout tags/v0.1.0
 
 # Return to the original path.
 cd -


### PR DESCRIPTION
…to the code folder before installing.

This circumvents needing the user to navigate to ~/.venv/airflow/src/ to pull changes.