### PR TITLE
Add variables to disable non-core models by default. Individual Stadi…

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -33,6 +33,14 @@ models:
     +tags: ['bypass_rls']
 
 vars:
+  # Enable optional domains and programs
+  'src:domain:assessment:enabled': False
+  'src:domain:discipline:enabled': False
+  'src:program:special_ed:enabled': False
+  'src:program:homeless:enabled': False
+  'src:program:language_instruction:enabled': False
+  'src:program:title_i:enabled': False
+
   # labels for generated race/ethnicity groups
   'edu:stu_demos:multiple_races_code': Multiple
   'edu:stu_demos:hispanic_latino_code': Latinx


### PR DESCRIPTION
…um implementations can customize these as needed based on the quality of the data in the ODS.

All models in edu_wh and edu_edfi_source are tagged, and the enabled-status of optional models are dependent on the value of these variables (defaulting to True if undefined).