### PR TITLE
Seed column types

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -60,3 +60,14 @@ vars:
 seeds:
   +schema: seed
   +quote_columns: false
+  edu_project_template:
+    student:
+      xwalk_subgroup_category_display_names:
+        +column_types:
+          subgroup_category: string
+          subgroup_category_display_name: string
+      xwalk_subgroup_value_display_names:
+        +column_types:
+          subgroup_category: string
+          subgroup_value: string
+          subgroup_value_display_name: string


### PR DESCRIPTION
Add column types for student subgroup seeds. If the seeds are empty and the column types are not set, `dim_subgroup` will break