### PR TITLE
fix for recent breaking change with lower bound that applies absentee categories

### DIFF
--- a/dbt/seeds/metric_thresholds/absentee_categories.csv
+++ b/dbt/seeds/metric_thresholds/absentee_categories.csv
@@ -1,5 +1,5 @@
 metric_name,threshold_lower,threshold_upper,level_numeric,level_label,level_color
-absentee_category,0,80,4,4 - Severe Chronic Absence,red
+absentee_category,-1,80,4,4 - Severe Chronic Absence,red
 absentee_category,80,90,3,3 - Moderate Chronic Absence,orange
 absentee_category,90,95,2,2 - At Risk Attendance,yellow
 absentee_category,95,101,1,1 - Satisfactory Attendance,green


### PR DESCRIPTION
this line: https://github.com/edanalytics/edu_wh/blob/91a42b04437e4c26f30d96641b80981b484fb3b2/models/core_warehouse/fct_student_daily_attendance.sql#L187

will assign students with 0% attendance rate to NULL `absentee_category_rank`, unless you change the xwalk to have a lower bound of `-1`


