### PR TITLE
Add grade levels csv with Ed-Fi standard grades

### DIFF
--- a/dbt/seeds/xwalk_grade_levels.csv
+++ b/dbt/seeds/xwalk_grade_levels.csv
@@ -1,0 +1,23 @@
+grade_level,grade_level_integer
+Infant/toddler,-3
+Early Education,-2
+Preschool/Prekindergarten,-1
+Kindergarten,0
+First grade,1
+Second grade,2
+Third grade,3
+Fourth grade,4
+Fifth grade,5
+Sixth grade,6
+Seventh grade,7
+Eighth grade,8
+Ninth grade,9
+Tenth grade,10
+Eleventh grade1,11
+Twelfth grade,12
+Grade 13,13
+Postsecondary,20
+Adult Education,30
+No grade level,99
+Other,99
+Ungraded,99

--- a/dbt/seeds/xwalk_grade_levels.csv
+++ b/dbt/seeds/xwalk_grade_levels.csv
@@ -18,6 +18,6 @@ Twelfth grade,12
 Grade 13,13
 Postsecondary,20
 Adult Education,30
-No grade level,99
-Other,99
-Ungraded,99
+No grade level,
+Other,
+Ungraded,


### PR DESCRIPTION
## Description & motivation
Add a seed file to map string grade levels to integer grade level for sorting. Includes Ed-Fi standard grade levels. **Depends on [edu_wh/pull/77](https://github.com/edanalytics/edu_wh/pull/77)**. I'm open to feedback on the sorting of the non pk-12 grades.

## Changes to existing models:
none

## New models created:
- `dbt/seeds/xwalk_grade_levels.csv`: new seed file with two columns (1) grade_level, (2) grade_level_integer 

## Tests and QC done:
Tested in Jeffco with added values specific to Jeffco's namespace.

## PR Merge Priority:
- Low - there is no clear deadline or motivating project for this feature