### PR TITLE
enable program assoc by default

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -63,13 +63,13 @@ vars:
    # Enable optional domains and programs
   'src:domain:assessment:enabled': False
   'src:domain:discipline:enabled': True
-  'src:program:special_ed:enabled': False
-  'src:program:homeless:enabled': False
-  'src:program:language_instruction:enabled': False
-  'src:program:title_i:enabled': False
-  'src:program:migrant_education:enabled': False
-  'src:program:cte:enabled': False
-  'src:program:food_service:enabled': False
+  'src:program:special_ed:enabled': True
+  'src:program:homeless:enabled': True
+  'src:program:language_instruction:enabled': True
+  'src:program:title_i:enabled': True
+  'src:program:migrant_education:enabled': True
+  'src:program:cte:enabled': True
+  'src:program:food_service:enabled': True
 
 seeds:
   +schema: seed


### PR DESCRIPTION
we have learned through newer projects that it'd be better to enable these models by default, to not confuse the team when inventorying data at beginning of the project. they are often populated, and even if not, they won't take up much compute