### PR TITLE
Feature/airflow 2.11

### DIFF
--- a/airflow/dags/edfi_resources_to_snowflake.py
+++ b/airflow/dags/edfi_resources_to_snowflake.py
@@ -2,16 +2,13 @@ import importlib
 
 from util import io_helpers
 
+from airflow.utils.dag_parsing_context import get_parsing_context
 from airflow.utils.task_group import TaskGroup
 
 from edu_edfi_airflow import EdFiResourceDAG
 
-### Optimizing DAG parsing delays during execution (only Airflow 2.4+)
-if importlib.metadata.version('apache-airflow') >= '2.4':
-    from airflow.utils.dag_parsing_context import get_parsing_context
-    __current_dag_id__ = get_parsing_context().dag_id
-else:
-    __current_dag_id__ = None
+### Optimizing DAG parsing delays during execution
+__current_dag_id__ = get_parsing_context().dag_id
 
 
 # Turning on descriptor DAGs doubles the total number processed by Airflow.

--- a/init/venv-airflow-init.sh
+++ b/init/venv-airflow-init.sh
@@ -1,5 +1,5 @@
 # Set versions to install into Airflow virtual environment
-AIRFLOW_VERSION=2.9.3
+AIRFLOW_VERSION=2.11.0
 
 EA_AIRFLOW_UTIL_VERSION=0.3.6
 EDFI_API_CLIENT_VERSION=0.2.3


### PR DESCRIPTION
## Description & motivation
This PR upgrades the edu_project_template from `Airflow 2.9.3` to `2.11.0`, the final 2.x release before 3.x. This upgrade brings:
- John's bugfix ([apache/airflow#43978](https://github.com/apache/airflow/pull/43978)).
- DAG cleanups for 2.11

The main changes are:
- Updated airflow version in `venv-airflow-init.sh` file.
- A fix for a silently broken string version comparison that would disable DAG parsing optimization in versions 2.10+.

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## Changes to existing files:

**Airflow version bump:**
- `init/venv-airflow-init.sh`:
  - Bumped `AIRFLOW_VERSION` from `2.9.3` to `2.11.0`.
  
**DAG parsing performance fix:**
- `edfi_resources_to_snowflake.py`:
  - Removed the version-gated `if importlib.metadata.version('apache-airflow') >= '2.4'` check around `get_parsing_context()`. The string comparison silently fails for `2.11.0` (`'2.11.0' < '2.4'` in string format since it is treating each character as an alphabetical comparison), which would disable the DAG parsing optimization and cause all DAGs to be fully parsed every scheduler cycle. Since we now require 2.4+, the version check is unnecessary.